### PR TITLE
Fix for node native modules

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -56,8 +56,12 @@ COPY ./package.json ./app/
 # NPM i app
 RUN npm i  --prefix /app
 
+
 # Move app to filesystem
 COPY . ./app
+
+# NPM rebuild node native modules after electron is installed.
+RUN ./app/node_modules/.bin/electron-rebuild
 
 # Start app
 CMD ["bash", "/app/start.sh"]

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "js"
   ],
   "dependencies": {
-    "electron-prebuilt": "^1.1.3"
+    "electron-prebuilt": "^1.1.3",
+    "electron-rebuild" :"*"
   },
   "author": "Carlo Maria Curinga",
   "license": "Apache-2.0",


### PR DESCRIPTION
Node modules need to be rebuilt for electron on ARM for resin.io to work with them.
