### PR TITLE
Use electron instead of electron-prebuilt

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -4,8 +4,8 @@
   "description": "electronJS-based resin application",
   "main": "main.js",
   "scripts": {
-    "start": "NODE_ENV=production startx ./node_modules/electron-prebuilt/dist/electron .",
-    "test": "NODE_ENV=development startx ./node_modules/electron-prebuilt/dist/electron ."
+    "start": "NODE_ENV=production startx ./node_modules/electron/dist/electron .",
+    "test": "NODE_ENV=development startx ./node_modules/electron/dist/electron ."
   },
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
     "js"
   ],
   "dependencies": {
-    "electron-prebuilt": "^1.3.4",
+    "electron": "^1.3.4",
     "electron-rebuild" :"^1.2.1"
   },
   "author": "Carlo Maria Curinga",

--- a/app/start.sh
+++ b/app/start.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# using electron-prebuilt module instead of the global electron let's you
+# using local electron module instead of the global electron lets you
 # easily control specific version dependency between your app and electron itself.
 # the syntax below starts an X istance with ONLY our electronJS fired up,
 # it saves you a LOT of resources avoiding full-desktops envs
 
 while true; do
     rm /tmp/.X0-lock &>/dev/null || true
-    startx /usr/src/app/node_modules/electron-prebuilt/dist/electron /usr/src/app --enable-logging
+    startx /usr/src/app/node_modules/electron/dist/electron /usr/src/app --enable-logging
 done


### PR DESCRIPTION
`electron-prebuilt` is deprecated and will no longer receive updates after 2016. `electron` is the recommended package name to use.
