### PR TITLE
pin to last know working xserver-xorg-input-all version

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
   apt-utils \
   clang \
   xserver-xorg-core \
-  xserver-xorg-input-all \
+  xserver-xorg-input-all=1:7.7+7+b1 \
   xserver-xorg-video-fbdev \
   xorg \
   libdbus-1-dev \


### PR DESCRIPTION
latest version of ` xserver-xorg-input-all` metapackage introduced a debian sid-only dependency breaking the build, so I pinned the latest working version of that metapackage until they fix upstream the latest 