### PR TITLE
switch (again) to electron-rebuild

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -45,7 +45,7 @@ COPY ./app/package.json ./
 
 # Install npm modules for the application
 RUN JOBS=MAX npm install --unsafe-perm --production \
-	&& npm cache clean &&
+	&& npm cache clean && node_modules/.bin/electron-rebuild
 
 # Move app to filesystem
 COPY ./app ./

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM resin/%%RESIN_MACHINE_NAME%%-node:6.9.2
+FROM resin/%%RESIN_MACHINE_NAME%%-node:6.9
 
 # debian httpredir mirror proxy often ends up with 404s - editing source file to avoid it
 RUN sed -i "s!httpredir.debian.org!`curl -s -D - http://httpredir.debian.org/demo/debian/ | awk '/^Link:/ { print $2 }' | sed -e 's@<http://\(.*\)/debian/>;@\1@g'`!" /etc/apt/sources.list
@@ -37,21 +37,18 @@ RUN echo "#!/bin/bash" > /etc/X11/xinit/xserverrc \
   && echo "" >> /etc/X11/xinit/xserverrc \
   && echo 'exec /usr/bin/X -s 0 dpms -nocursor -nolisten tcp "$@"' >> /etc/X11/xinit/xserverrc
 
-# Save source folder
-RUN printf "%s\n" "${PWD##}" > SOURCEFOLDER
-
 # Move to app dir
 WORKDIR /usr/src/app
 
 # Move package.json to filesystem
-COPY "$SOURCEFOLDER/app/package.json" ./
+COPY ./app/package.json ./
 
 # Install npm modules for the application
 RUN JOBS=MAX npm install --unsafe-perm --production \
-	&& npm cache clean
+	&& npm cache clean &&
 
 # Move app to filesystem
-COPY "$SOURCEFOLDER/app" ./
+COPY ./app ./
 
 ## uncomment if you want systemd
 ENV INITSYSTEM on

--- a/app/main.js
+++ b/app/main.js
@@ -1,4 +1,3 @@
-require('require-rebuild')();
 const electron = require('electron');
 const path = require('path');
 

--- a/app/package.json
+++ b/app/package.json
@@ -19,8 +19,8 @@
     "js"
   ],
   "dependencies": {
-    "electron": "^1.4.13",
-    "require-rebuild": "^1.2.8"
+    "electron": "^1.4.15",
+    "electron-rebuild": "^1.5.7"
   },
   "author": "Carlo Maria Curinga",
   "license": "Apache-2.0",


### PR DESCRIPTION
fixes #36 

this allows free usage of latest `electron` versions and moves finally back to the builder the native module rebuilding