### PR TITLE
set default TFT_ROTATE value

### DIFF
--- a/app/start.sh
+++ b/app/start.sh
@@ -9,7 +9,7 @@ rm /tmp/.X0-lock &>/dev/null || true
 
 if [ ! -c /dev/fb1 ]; then
   modprobe spi-bcm2708 || true
-  modprobe fbtft_device name=pitft verbose=0 rotate=$TFT_ROTATE || true
+  modprobe fbtft_device name=pitft verbose=0 rotate=${TFT_ROTATE-0} || true
 
   sleep 1
 

--- a/app/start.sh
+++ b/app/start.sh
@@ -9,7 +9,7 @@ rm /tmp/.X0-lock &>/dev/null || true
 
 if [ ! -c /dev/fb1 ]; then
   modprobe spi-bcm2708 || true
-  modprobe fbtft_device name=pitft verbose=0 rotate=${TFT_ROTATE-0} || true
+  modprobe fbtft_device name=pitft verbose=0 rotate=${TFT_ROTATE:-0} || true
 
   sleep 1
 


### PR DESCRIPTION
For setting the parameter of `fbtft_device`. Set the default value to `0`.
Connects to #38