### PR TITLE
Allow setting the local timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ simply set these [environment varables](http://docs.resin.io/#/pages/management/
 * **`URL_LAUNCHER_TOUCH_SIMULATE`** *bool* (converted from *string*) - simulates touch events - might be useful for touchscreen with partial driver support - be aware this could be a performance hog  - *defaults to* `0`
 * **`URL_LAUNCHER_ZOOM`** *float* (converted from *string*) - The default zoom factor of the page, 3.0 represents 300%  - *defaults to* `1.0`
 * **`URL_LAUNCHER_OVERLAY_SCROLLBARS`** *bool* (converted from *string*) - enables overlay scrollbars  - *defaults to* `0`
+* **`TIMEZONE`** *string* - the timezone to use. Examples: `Europe/Berlin` or `America/Los_Angeles` - *defaults to* `UTC`
 
 ### Related
 

--- a/app/start.sh
+++ b/app/start.sh
@@ -4,6 +4,19 @@
 # pages we need more.
 umount /dev/shm && mount -t tmpfs shm /dev/shm
 
+# Set timezone
+if [[ -n "$TIMEZONE" ]]
+then
+  # Check whether provided timezone is valid
+  if [[ -e "/usr/share/zoneinfo/${TIMEZONE}" ]]
+  then
+    echo "Set timezone to ${TIMEZONE}."
+    ln -sf "/usr/share/zoneinfo/${TIMEZONE}" /etc/localtime
+  else
+    echo "Invalid timezone: ${TIMEZONE}." >&2
+  fi
+fi
+
 # using local electron module instead of the global electron lets you
 # easily control specific version dependency between your app and electron itself.
 # the syntax below starts an X istance with ONLY our electronJS fired up,


### PR DESCRIPTION
This introduces a new environment variable `TIMEZONE` so that users can set the local timezone in the container. By default `UTC` is used which may not be ideal for everyone, especially when displaying time. 