### PR TITLE
feat(app): Add API for resin update locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,52 @@ simply set these [environment varables](http://docs.resin.io/#/pages/management/
 * **`TFT`** *bool* (converted from *string*) - sets the target display to TFT screen like the [piTFT](https://www.adafruit.com/product/1601) but still requires you to set the proper device tree overlay configuration for it  - *defaults to* `0`
 * **`TFT_ROTATE`**  *int* (converted from *string*) - accepted values: 0,90,180,270 - *defaults to* `0`
 * **`ELECTRON_ENABLE_HW_ACCELERATION`**  *bool* (converted from *string*) - enable hardware acceleration - *defaults to* `0`
+* **`ELECTRON_RESIN_UPDATE_LOCK`**  *bool* (converted from *string*) - Enable supervisor update locking (see [Update Locking](#update-locking))
+
+### Update Locking
+
+**NOTE:** Take care to only listen for a response *once*, and avoid sending
+multiple requests before the response arrived.
+
+```js
+const {ipcRenderer} = require('electron')
+```
+
+#### Acquiring the Lock
+
+```js
+// Listen for a response
+ipcRenderer.once('resin-update-lock', (event, error) => {
+  if (error) { ... }
+})
+
+// Send the 'lock' command to acquire the lock
+ipcRenderer.send('resin-update-lock', 'lock')
+```
+
+#### Releasing the Lock
+
+```js
+// Listen for a response
+ipcRenderer.once('resin-update-lock', (event, error) => {
+  if (error) { ... }
+})
+
+// Send the 'unlock' command to release the lock
+ipcRenderer.send('resin-update-lock', 'unlock')
+```
+
+#### Checking the Lock
+
+```js
+// Listen for a response
+ipcRenderer.once('resin-update-lock', (event, error, isLocked) => {
+  console.log('Locked:', error || isLocked)
+})
+
+// Send the 'check' command to check on the state of the lock
+ipcRenderer.send('resin-update-lock', 'check')
+```
 
 ### Related
 

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "NODE_ENV=development electron .",
     "lint": "eslint .",
-    "start": "NODE_ENV=production startx ./node_modules/electron/dist/electron ."
+    "start": "NODE_ENV=production startx ./node_modules/electron/dist/electron .",
+    "local": "NODE_ENV=production electron ."
   },
   "repository": {
     "type": "git",
@@ -20,7 +21,8 @@
   ],
   "dependencies": {
     "electron": "~1.6.16",
-    "electron-rebuild": "^1.7.2"
+    "electron-rebuild": "^1.7.2",
+    "lockfile": "^1.0.4"
   },
   "author": "Carlo Maria Curinga",
   "license": "Apache-2.0",


### PR DESCRIPTION
This adds an IPC API for acquiring & releasing resin app update locks from the renderer process, which can be enabled through `ELECTRON_RESIN_UPDATE_LOCK`.

Change-Type: minor
Connects To: https://github.com/resin-io/etcher/issues/2258