### PR TITLE
Fix issue with Buster base image and add support for arm64

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,7 +1,7 @@
 ###
 # Build stage
 ##
-FROM balenalib/raspberrypi3-node:10-build as build
+FROM balenalib/raspberrypi3-node:12-buster-build as build
 
 # Move to app dir
 WORKDIR /usr/src/app
@@ -39,7 +39,7 @@ RUN    JOBS=MAX npm install --unsafe-perm --production \
 ###
 # Runtime
 ##
-FROM balenalib/raspberrypi3-node:10-run
+FROM balenalib/raspberrypi3-node:12-buster-run
 
 # Move to app dir
 WORKDIR /usr/src/app

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,7 +1,7 @@
 ###
 # Build stage
 ##
-FROM balenalib/%%BALENA_MACHINE_NAME%%-node:10-build as build
+FROM balenalib/raspberrypi3-node:10-build as build
 
 # Move to app dir
 WORKDIR /usr/src/app
@@ -39,7 +39,7 @@ RUN    JOBS=MAX npm install --unsafe-perm --production \
 ###
 # Runtime
 ##
-FROM balenalib/%%BALENA_MACHINE_NAME%%-node:10-run
+FROM balenalib/raspberrypi3-node:10-run
 
 # Move to app dir
 WORKDIR /usr/src/app

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,7 +1,7 @@
 ###
 # Build stage
 ##
-FROM balenalib/%%BALENA_MACHINE_NAME%%-node:10-build as build
+FROM balenalib/%%BALENA_MACHINE_NAME%%-node:12-buster-build as build
 
 # Move to app dir
 WORKDIR /usr/src/app
@@ -39,7 +39,7 @@ RUN    JOBS=MAX npm install --unsafe-perm --production \
 ###
 # Runtime
 ##
-FROM balenalib/%%BALENA_MACHINE_NAME%%-node:10-run
+FROM balenalib/%%BALENA_MACHINE_NAME%%-node:12-buster-run
 
 # Move to app dir
 WORKDIR /usr/src/app


### PR DESCRIPTION
-  replace `libgnome-keyring` with `libsecret`
- add dockerfile targeting arm64

Change-type: minor
Signed-off-by: Rahul Thakoor <rahul@balena.io>